### PR TITLE
Update throttle access

### DIFF
--- a/lib/qless/queue.rb
+++ b/lib/qless/queue.rb
@@ -69,13 +69,18 @@ module Qless
       set_config :heartbeat, value
     end
 
+    def throttle
+      @throttle ||= Qless::Throttle.new("ql:q:#{name}", client)
+    end
+
     def max_concurrency
-      value = JSON.parse(@client.call('queue.throttle.get', @name))['maximum']
-      value && Integer(value)
+      warn "[DEPRECATED - 4/17/14] `max_concurrency` is deprecated. Use `throttle.maximum` instead."
+      throttle.maximum
     end
 
     def max_concurrency=(value)
-      @client.call('queue.throttle.set', @name, value)
+      warn "[DEPRECATED - 4/17/14] `max_concurrency=` is deprecated. Use `throttle.maximum=` instead."
+      throttle.maximum = value
     end
 
     def paused?

--- a/spec/integration/queue_spec.rb
+++ b/spec/integration/queue_spec.rb
@@ -75,6 +75,10 @@ module Qless
       pending('this is specific to ruby')
     end
 
+    it 'exposes a throttle' do
+      expect(queue.throttle).to be
+    end
+
     it 'exposes max concurrency' do
       queue.max_concurrency = 5
       expect(queue.max_concurrency).to eq(5)

--- a/spec/unit/queue_spec.rb
+++ b/spec/unit/queue_spec.rb
@@ -94,6 +94,14 @@ module Qless
       include_examples 'job options'
     end
 
+    describe "#throttle" do
+      let(:q) { Queue.new('a_queue', client) }
+
+      it "returns a Qless::Throttle" do
+        expect(q.throttle).to be_a(Qless::Throttle)
+      end
+    end
+
     describe "equality" do
       it 'is considered equal when the qless client and name are equal' do
         q1 = Qless::Queue.new('foo', client)


### PR DESCRIPTION
updates throttle access for Qless::Queue. Deprecates max_concurrency and max_concurrency=.
