### PR TITLE
Use constantize

### DIFF
--- a/lib/qless/job.rb
+++ b/lib/qless/job.rb
@@ -18,7 +18,7 @@ module Qless
 
     def klass
       @klass ||= @klass_name.split('::').reduce(Object) do |context, name|
-        context.const_get(name)
+        context.const_get(name, false)
       end
     end
 


### PR DESCRIPTION
Currently, Qless::Job attempts to find constants by splitting the worker_class string (e.g., `'Jobs::GoogleMail::Backup::Master'` becomes `['Jobs', 'GoogleMail', 'Backup', 'Master']` and looking up each successive constant within the scope of the previous constant. This works most of the time. However, if you have constants like `A::B::C` and `B::X`, given `'A::B::C'`, Qless will incorrectly return the `B` associated with `B::X` and throw a NameError trying to find `C` within that `B`. This restricts the way we can name things in CORE. Given the entire properly scoped class name, `constantize` doesn't run into this issue.